### PR TITLE
fip/radio-metadata: ignore isolated errors

### DIFF
--- a/src/fip/radio-metadata/test.ts
+++ b/src/fip/radio-metadata/test.ts
@@ -1,0 +1,90 @@
+import Bacon from "baconjs";
+import { ignoreNonRecurringErrors } from "./index";
+
+test("ignoreNonRecurringErrors should ignore errors if less than `threshold`", done => {
+  const stream = new Bacon.Bus();
+
+  const unsubscribe = ignoreNonRecurringErrors(20, 5, stream).subscribe(
+    event => {
+      unsubscribe();
+      expect(event.isEnd()).toBeTruthy();
+      done();
+    }
+  );
+
+  stream.error(1);
+  stream.error(2);
+  stream.error(3);
+  stream.error(4);
+  stream.end();
+});
+
+test("ignoreNonRecurringErrors should ignore errors if less than `threshold` in `interval`", done => {
+  const stream = new Bacon.Bus();
+
+  const unsubscribe = ignoreNonRecurringErrors(20, 5, stream).subscribe(
+    event => {
+      unsubscribe();
+      expect(event.isEnd()).toBeTruthy();
+      done();
+    }
+  );
+
+  stream.error(1);
+  stream.error(2);
+  stream.error(3);
+  stream.error(4);
+
+  setTimeout(() => {
+    stream.error(5);
+    stream.error(6);
+    stream.end();
+  }, 30);
+});
+
+test("ignoreNonRecurringErrors should throw last error if `threshold` is met within `interval`", done => {
+  const stream = new Bacon.Bus();
+
+  const unsubscribe = ignoreNonRecurringErrors(20, 5, stream).subscribe(
+    event => {
+      unsubscribe();
+      expect(event.isError()).toBeTruthy();
+
+      expect((event as Bacon.Error<any>).error).toStrictEqual(7);
+      done();
+    }
+  );
+
+  stream.error(1);
+  stream.error(2);
+  stream.error(3);
+  stream.error(4);
+
+  setTimeout(() => {
+    stream.error(5);
+    stream.error(6);
+    stream.error(7);
+  }, 10);
+
+  setTimeout(() => {
+    stream.error(8);
+    stream.error(9);
+    stream.end();
+  }, 30);
+});
+
+test("ignoreNonRecurringErrors should not block values", done => {
+  const stream = new Bacon.Bus();
+
+  const unsubscribe = ignoreNonRecurringErrors(20, 5, stream).subscribe(
+    event => {
+      unsubscribe();
+      expect(event.hasValue()).toBeTruthy();
+      expect(event.value()).toStrictEqual(42);
+      done();
+    }
+  );
+
+  stream.push(42);
+  stream.end();
+});


### PR DESCRIPTION
**What**

This PR makes parsing errors a bit less noisy, by emitting only the ones that happen somewhat consistently (i.e. 5 times in a window of 12 seconds).

**Why**

Fip's API returns empty content time to time, making the song parser a bit sad. I assume that in most cases, the error is not noticeable by users as the last parsed song is still the one being played. By filtering out the "one-off" exceptions, we should make them more visible.